### PR TITLE
Drop route based context logging

### DIFF
--- a/eidaws.federator/eidaws/federator/fdsnws_availability/process.py
+++ b/eidaws.federator/eidaws/federator/fdsnws_availability/process.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from eidaws.federator.utils.httperror import FDSNHTTPError
+from eidaws.federator.utils.misc import create_job_context
 from eidaws.federator.utils.process import group_routes_by, SortedResponse
 from eidaws.federator.version import __version__
 from eidaws.federator.utils.worker import (
@@ -45,7 +46,11 @@ class AvailabilityWorker(NetworkLevelMixin, BaseWorker):
                 _route,
                 parser_cb=self._parse_response,
                 req_method=req_method,
-                context={"logger_ctx": self.create_job_context(route, _route)},
+                context={
+                    "logger_ctx": create_job_context(
+                        self.request, parent_ctx=context.get("logger_ctx")
+                    )
+                },
                 **req_kwargs,
             )
             for _route in route
@@ -146,7 +151,7 @@ class AvailabilityRequestProcessor(SortedResponse):
         _sorted = sorted(grouped_routes)
         for priority, net in enumerate(_sorted):
             _routes = grouped_routes[net]
-            ctx = {"logger_ctx": self.create_job_context(_routes)}
+            ctx = {"logger_ctx": create_job_context(self.request)}
             self.logger.debug(
                 f"Creating job: context={ctx!r}, priority={priority}, "
                 f"network={net!r}, route={_routes!r}"

--- a/eidaws.federator/eidaws/federator/utils/misc.py
+++ b/eidaws.federator/eidaws/federator/utils/misc.py
@@ -9,7 +9,6 @@ import logging.handlers  # needed for handlers defined in logging.conf
 import uuid
 
 from aiohttp import web, TCPConnector
-from hashlib import md5
 
 from eidaws.federator.settings import (
     FED_BASE_ID,
@@ -184,10 +183,10 @@ class HelperPOSTRequest:
 
 
 # ----------------------------------------------------------------------------
-def route_to_uuid(route):
-    h = md5(str(route).encode("utf-8"))
-    return uuid.UUID(bytes=h.digest())
+def create_job_context(request, parent_ctx=None):
+    if parent_ctx is None:
+        return [request, uuid.uuid4()]
 
-
-def create_job_context(request, *routes):
-    return [request] + [route_to_uuid(route) for route in routes]
+    ctx = parent_ctx[:]
+    ctx.append(uuid.uuid4())
+    return ctx

--- a/eidaws.federator/eidaws/federator/utils/process.py
+++ b/eidaws.federator/eidaws/federator/utils/process.py
@@ -338,9 +338,6 @@ class BaseRequestProcessor(CachingMixin, ClientRetryBudgetMixin, ConfigMixin):
             # TODO(damb): Finalization prevents access logs being output
             await asyncio.shield(self.finalize())
 
-    def create_job_context(self, *routes):
-        return create_job_context(self.request, *routes)
-
     def make_stream_response(self, *args, **kwargs):
         """
         Factory for a :py:class:`aiohttp.web.StreamResponse`.
@@ -550,7 +547,7 @@ class UnsortedResponse(BaseRequestProcessor):
         Dispatch jobs onto ``pool``.
         """
         for route in routes:
-            ctx = {"logger_ctx": self.create_job_context(route)}
+            ctx = {"logger_ctx": create_job_context(self.request)}
             self.logger.debug(
                 f"Creating job: context={ctx!r}, route={route!r}"
             )

--- a/eidaws.federator/eidaws/federator/utils/worker.py
+++ b/eidaws.federator/eidaws/federator/utils/worker.py
@@ -20,7 +20,6 @@ from eidaws.federator.utils.misc import (
 )
 from eidaws.federator.utils.request import FdsnRequestHandler
 from eidaws.federator.utils.tempfile import AioSpooledTemporaryFile
-from eidaws.federator.utils.misc import create_job_context
 from eidaws.utils.error import ErrorWithTraceback
 from eidaws.utils.misc import (
     _callable_or_raise,
@@ -192,9 +191,6 @@ class BaseWorker(ClientRetryBudgetMixin, ConfigMixin):
         """
         Template coro intented to be called when finializing a job.
         """
-
-    def create_job_context(self, *routes):
-        return create_job_context(self.request, *routes)
 
     def _log_request(self, req_handler, method, logger=None):
         logger = logger or self.logger


### PR DESCRIPTION
**Features and Changes**:
- Avoid blocking the event loop when generating logger contexts; use random UUIDs instead